### PR TITLE
Update google-maps.js

### DIFF
--- a/apps/static/assets/js/pages/google-maps.js
+++ b/apps/static/assets/js/pages/google-maps.js
@@ -72,7 +72,7 @@ $(document).ready(function() {
     });
     mapT.addMapType("osm", {
         getTileUrl: function(coord, zoom) {
-            return "https://a.tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+            return "https://tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
         },
         tileSize: new google.maps.Size(256, 256),
         name: "OpenStreetMap",


### PR DESCRIPTION
`a.` is no longer recommended now that we support HTTP/2 + HTTP/3.